### PR TITLE
Only run script on github.com

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
   "content_scripts": [
     {
       "matches": [
-        "*://*/*"
+        "*://github.com/*"
       ],
       "js": [
         "content_script.js"


### PR DESCRIPTION
Previous version loads the extension on all sites.  This change makes it load only on github.com.