### PR TITLE
Default to removing the dark header

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -1,9 +1,12 @@
 var element = document.getElementsByClassName("header-dark")[0];
 if (element) {
-    chrome.storage.sync.get(['enabled'], function (results) {
+    // Default to removing the border
+    element.className = element.className.replace(/\header-dark\b/, '');
 
+    // check storage if we want it back
+    chrome.storage.sync.get(['enabled'], function (results) {
         if (results.enabled || results.enabled === undefined) {
-            element.className = element.className.replace(/\header-dark\b/, '');
+            element.className += " header-dark";
         }
     });
 }


### PR DESCRIPTION
This way you don't have the flickering header when the extension is enabled. This makes more sense since most people will want the header to be gone anyways while still allowing you to disable it temporarily