### PR TITLE
DOM listeners to load asap

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,7 @@
       "js": [
         "src/content_script.js"
       ],
-      "run_at": "document_end"
+      "run_at": "document_start"
     }
   ]
 }

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -1,9 +1,12 @@
 var element = document.getElementsByClassName("header-dark")[0];
 if (element) {
-    chrome.storage.sync.get(['enabled'], function (results) {
+    // Default to removing the border
+    element.className = element.className.replace(/\header-dark\b/, '');
 
+    // check storage if we want it back
+    chrome.storage.sync.get(['enabled'], function (results) {
         if (results.enabled || results.enabled === undefined) {
-            element.className = element.className.replace(/\header-dark\b/, '');
+            element.className += " header-dark";
         }
     });
 }

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -1,12 +1,28 @@
-var element = document.getElementsByClassName("header-dark")[0];
-if (element) {
-    // Default to removing the border
-    element.className = element.className.replace(/\header-dark\b/, '');
+var hasReplaced = false;
 
-    // check storage if we want it back
-    chrome.storage.sync.get(['enabled'], function (results) {
-        if (results.enabled || results.enabled === undefined) {
-            element.className += " header-dark";
+function replaceHeader() {
+    // check if we already replaced the header class
+    if (hasReplaced === false) {
+
+        // check if element exists yet
+        var element = document.getElementsByClassName("header-dark")[0];
+        if (element) {
+            // element exists, store it so we don't run this twice
+            hasReplaced = true;
+
+            // Default to always removing the border
+            element.className = element.className.replace(/\header-dark\b/, '');
+
+            // check storage if we want it back
+            chrome.storage.sync.get(['enabled'], function (results) {
+                if (results.enabled || results.enabled === undefined) {
+                    element.className += " header-dark";
+                }
+            });
         }
-    });
+    }
 }
+
+// Dom event listeners
+document.addEventListener('DOMNodeInserted', replaceHeader);
+document.addEventListener("DOMContentLoaded", replaceHeader);


### PR DESCRIPTION
It uses DOMNodeInserted and DOMContentLoaded while putting document_start in the manifest to load the content script as soon as possible. That way when the header is inserted we can remove it instantly 