### PR TITLE
Numerous improvements/refactoring for the Chrome extension

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,19 +1,19 @@
 {
   "manifest_version": 2,
-  "name": "MakeGithubGreatAgain",
+  "name": "Make GitHub Great Again",
   "version": "1.2.0",
-  "description": "Extension to make GitHub great again!.",
+  "description": "Extension to make GitHub great again!",
+  "minimum_chrome_version": "26",
   "icons": {
     "16": "icon_16.png",
     "48": "icon_48.png",
     "128": "icon_128.png"
   },
-  "browser_action": {
-    "default_icon": "icon_16.png"
+  "page_action": {
+    "default_title": "Toggle light/dark header"
   },
   "permissions": [
-    "storage",
-    "tabs"
+    "storage"
   ],
   "background": {
     "persistent": false,

--- a/src/background.js
+++ b/src/background.js
@@ -1,13 +1,22 @@
-chrome.browserAction.onClicked.addListener(function (tab) {
+chrome.pageAction.onClicked.addListener(function (tab) {
     // icon was clicked
     chrome.storage.sync.get(['enabled'], function (results) {
-
         // store new swapped setting
         chrome.storage.sync.set({'enabled': !results.enabled});
 
-        // refresh current page
-        chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-            chrome.tabs.update(tabs[0].id, {url: tabs[0].url});
+        // Chrome doesn't have an easy way to broadcast a message to all
+        // content scripts, so just broadcast the message to every tab
+        // and rely on Chrome's manifest permission to restrict
+        chrome.tabs.query({}, function (tabs) {
+            tabs.forEach(function (tab) {
+                chrome.tabs.sendMessage(tab.id, 'toggle_style', function () {});
+            });
         });
     })
+});
+
+chrome.runtime.onMessage.addListener(function (message, sender, callback) {
+    if (message === 'enable_page_action') {
+        chrome.pageAction.show(sender.tab.id);
+    }
 });


### PR DESCRIPTION
- Change browser action to page action

  They look similar on recent Chrome versions, however, page actions can be toggled on/off and it doesn't make sense to have the button enabled outside github.com

- Toggling the style will now affect other open GitHub tabs too, no need to reload the page!

  ![](https://cloud.githubusercontent.com/assets/6135313/22860528/83cbeff6-f13b-11e6-9e69-5e599a2baea4.gif)

- Fix bugged code logic at content script

  If there are no results for `getElementsByClassName()`, it will return `null`... but we immediately try to get the first result from the array, which will throw an Error... therefore the `if` statement beneath is completely pointless

```js
        // check if element exists yet
        var element = document.getElementsByClassName("header-dark")[0];
        if (element) {
```

- Remove scary “[Access your browsing activity](https://developer.chrome.com/extensions/permission_warnings)” permission, no need for that anymore

- Set Chrome minimum version to 26 as [`chrome.runtime.sendMessage`](https://developer.chrome.com/extensions/runtime#method-sendMessage) is used

  It's possible to make it work on even older Chrome versions, but seriously, upgrade :p