### PR TITLE
Fix gist.github.com and search box on both sites

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -2,7 +2,7 @@ var headerBar;
 
 function initOnce () {
     // check if element exists yet
-    headerBar = document.querySelector('body > div > header');
+    headerBar = document.querySelector('body > div > .Header');
     if (headerBar) {
         // element exists, remove the event listeners so we don't run this twice
         document.removeEventListener('DOMNodeInserted', initOnce);

--- a/src/header.css
+++ b/src/header.css
@@ -74,16 +74,23 @@
     border-top-color: #4078c0
 }
 
+/*
 .great-header .header-search {
     font-size: 14px
 }
+*/
 
 .great-header .header-search-wrapper {
     background: #fff;
+    /*
     box-shadow: inset 0 1px 2px rgba(0,0,0,0.075);
+    */
+    /* The search box had a gentle border */
     border: 1px solid #ddd;
+    /*
     font-size: 14px;
     min-height: 0;
+    */
 }
 
 .great-header .header-search-wrapper.focus {
@@ -94,15 +101,17 @@
     box-shadow: inset 0 1px 2px rgba(0, 0, 0, .075), 0 0 5px rgba(81, 167, 232, .5);
 }
 
+/*
 .great-header .header-search-scope {
     font-size: 12px;
     line-height: inherit;
     min-height: 0;
 }
 
-.great-header .header-search-input {
+.Header.great-header .header-search-input {
     min-height: 26px;
 }
+*/
 
 .great-header .header-search-input::-webkit-input-placeholder,
 .great-header .header-search-input::placeholder {
@@ -130,10 +139,6 @@
     color: #767676 !important;
 }
 
-/* The search box had a gentle border */
-.Header.great-header .header-search-wrapper {
-    border: 1px solid #ddd;
-}
 /* The selector next to the search box was just plain white (now fixed above) */
 /*
 .great-header .header-search-scope {

--- a/src/header.css
+++ b/src/header.css
@@ -1,4 +1,4 @@
-header.great-header {
+.Header.great-header {
     color: #333;
     background-color: #f5f5f5;
     border-bottom: 1px solid #e5e5e5
@@ -31,7 +31,7 @@ header.great-header {
     /* background-image: linear-gradient(#4078c0, #4078c0); */
 }
 
-header.great-header .header-search-scope {
+.Header.great-header .header-search-scope {
     font-size: inherit;
     color: #767676;
     border-right: 1px solid #eee;
@@ -131,7 +131,7 @@ header.great-header .header-search-scope {
 }
 
 /* The search box had a gentle border */
-header.great-header .header-search-wrapper {
+.Header.great-header .header-search-wrapper {
     border: 1px solid #ddd;
 }
 /* The selector next to the search box was just plain white (now fixed above) */
@@ -143,7 +143,7 @@ header.great-header .header-search-wrapper {
 
 /* According to my Firefox, the header did not used to be so tall */
 /* Some people might not want to go back to a short header, so I have made this a separate class.  Add it for a more faithful classic look. */
-header.short-header {
+.Header.short-header {
     padding-top: 10px;
     padding-bottom: 10px;
 }
@@ -153,14 +153,14 @@ header.short-header {
 }
 
 /* The search box was also less tall */
-header.short-search-box .header-search {
+.Header.short-search-box .header-search {
     margin-top: 1px;
 }
-header.short-search-box .header-search-scope {
+.Header.short-search-box .header-search-scope {
     line-height: 26px;
 }
-header.short-search-box .header-search-wrapper,
-header.short-search-box .header-search-input {
+.Header.short-search-box .header-search-wrapper,
+.Header.short-search-box .header-search-input {
     min-height: 26px;
 }
 /* The text to the right of the search box*/

--- a/src/links.css
+++ b/src/links.css
@@ -102,6 +102,8 @@
 .great-again .contributing a,
 /* The "Add a bio" link on your profile page /[username] */
 .great-again .vcard-names-container + .mb-3 a,
+/* List of repos in /settings/repositories */
+.great-again .js-collab-repo a,
 /* Links to Wiki pages */
 .great-again a.wiki-page-link {
     color: #4078c0;

--- a/src/links.css
+++ b/src/links.css
@@ -104,6 +104,8 @@
 .great-again .vcard-names-container + .mb-3 a,
 /* List of repos in /settings/repositories */
 .great-again .js-collab-repo a,
+/* List in cards on the /projects/1 page */
+.great-again .issue-card a,
 /* Links to Wiki pages */
 .great-again a.wiki-page-link {
     color: #4078c0;

--- a/src/links.css
+++ b/src/links.css
@@ -73,7 +73,10 @@
 .great-again .tos-info a,
 .great-again .vcard-details a,
 .great-again a.aname,
+/* Hovering a person's name on the "Followers/Following" tabs */
 .great-again a.link-gray-dark:hover,
+/* Hovering a person's username on the "Followers/Following" tabs */
+.great-again a.link-gray:hover,
 .great-again a.muted-link:hover,
 .great-again table.files td.message a:hover,
 .great-again td.content a,

--- a/src/links.css
+++ b/src/links.css
@@ -67,7 +67,7 @@
 .great-again .repo-list a,
 .great-again .repohead-details-container>h1 a,
 .great-again .repository-meta-content a,
-.great-again .site-footer a,
+.great-again .footer a:not(.footer-octicon),
 .great-again .tos-info a,
 .great-again .vcard-details a,
 .great-again a.aname,

--- a/src/links.css
+++ b/src/links.css
@@ -67,6 +67,8 @@
 .great-again .repo-list a,
 .great-again .repohead-details-container>h1 a,
 .great-again .repository-meta-content a,
+/* Links to repositories on the "Stars" tab */
+.great-again .d-inline-block h3 > a,
 .great-again .footer a:not(.footer-octicon),
 .great-again .tos-info a,
 .great-again .vcard-details a,

--- a/src/links.css
+++ b/src/links.css
@@ -60,6 +60,7 @@
 .great-again .pagination a,
 .great-again .pinned-repo-item-content .d-block a,
 .great-again .pinned-repo-item-content a,
+.great-again #user-repositories-list a,
 .great-again .profile-rollup-content>li>div>a:first-child,
 .great-again .profile-rollup-content>li>span>a,
 .great-again .protip a,

--- a/src/links.css
+++ b/src/links.css
@@ -59,6 +59,7 @@
 .great-again .numbers-summary a:hover,
 .great-again .pagination a,
 .great-again .pinned-repo-item-content .d-block a,
+.great-again .pinned-repo-item-content a,
 .great-again .profile-rollup-content>li>div>a:first-child,
 .great-again .profile-rollup-content>li>span>a,
 .great-again .protip a,


### PR DESCRIPTION
Today I found:

- On `gist.github.com` the script was not activating because it could not detect the header. That was because the element had changed (back) from a `<header>` to a `<div class="Header">`
- On both sites, Github have restyled their search box a little. It was conflicting with our grey header and smaller search box styles.

The last two commits in this PR fixes those urgent issues.

The earlier commits are just a backlog of less critical tweaks.

I hope it works for you, and I hope it will last for a while...!