### PR TITLE
Minor fixes

### DIFF
--- a/src/fonts-use-browser-mono.css
+++ b/src/fonts-use-browser-mono.css
@@ -1,0 +1,86 @@
+/* main font */
+body.great-again,
+.great-again .markdown-body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    /* font-size: 14px; line-height: 1.5; color: #24292e; background-color: #fff; */
+}
+
+/* monospace font styles from frameworks.css 2017/01/01 */
+.great-again code,
+.great-again kbd,
+.great-again pre,
+.great-again samp {
+    font-family: monospace, monospace;
+}
+.great-again tt,
+.great-again code {
+    font-family: monospace;
+}
+.great-again pre {
+    font: 12px monospace
+}
+.great-again .CodeMirror,
+.great-again .CodeMirror-dialog input,
+.great-again .file-editor-textarea,
+.great-again .input-monospace {
+    font-family: monospace, monospace;
+}
+.great-again .cm-s-github .CodeMirror-lines {
+    font-family: monospace;
+}
+
+/* monospace font styles from github.css 2017/01/01 */
+.great-again .branch-name {
+    font: 12px monospace;
+}
+.great-again .commit-ref {
+    font: 0.75em/2 monospace;
+}
+.great-again .commit .sha-block,
+.great-again .commit .sha {
+    font-family: monospace;
+}
+.great-again .commit-desc pre {
+    font-family: monospace;
+}
+.great-again .commit-tease-sha {
+    font-family: monospace;
+}
+.great-again .blob-num {
+    font-family: monospace;
+}
+.great-again .blob-code-inner {
+    font-family: monospace;
+}
+.great-again .gollum-editor .gollum-editor-body {
+    font-family: monospace;
+}
+.great-again .gollum-editor .expanded textarea {
+    font-family: monospace;
+}
+.great-again .gollum-dialog-dialog-body fieldset .code {
+    font-family: monospace;
+}
+.great-again kbd {
+    font: 11px monospace;
+}
+.great-again .credit-card .cvv {
+    font-family: monospace;
+}
+.great-again .credit-card .text {
+    font-family: monospace;
+}
+.great-again .default-label .sha {
+    font-family: monospace;
+}
+
+/* monospace font styles from site.css 2017/01/01 */
+.great-again .alt-mono-font {
+    font-family: monospace;
+}
+.great-again .pullquote {
+    font-family: monospace;
+}
+.great-again .casestudy-body blockquote {
+    font-family: monospace;
+}

--- a/src/links.css
+++ b/src/links.css
@@ -121,6 +121,8 @@
 .great-again .js-collab-repo a,
 /* List in cards on the /projects/1 page */
 .great-again .issue-card a,
+/* Name of the repo above search results */
+.great-again h3 a,
 /* Links to Wiki pages */
 .great-again a.wiki-page-link {
     color: #4078c0;

--- a/src/save-the-colors.css
+++ b/src/save-the-colors.css
@@ -216,6 +216,12 @@ a {
     background-color: #f2f8fa;
     border-bottom-color: #bfccd1;
 }
+.great-again .timeline-comment.current-user {
+    border-color: #bfccd1;
+}
+.great-again .timeline-comment-wrapper .timeline-comment.current-user::before {
+    border-right-color: #bfccd1;
+}
 /* The box that contains the big green "Merge pull request" button */
 .great-again .branch-action-body .merge-message,
 .great-again .branch-action-body .merge-branch-form {

--- a/src/save-the-colors.css
+++ b/src/save-the-colors.css
@@ -29,7 +29,8 @@ body.great-again {
 .great-again .state-open,
 .great-again .completeness-indicator-success,
 .great-again .branch-action-state-clean .branch-action-icon,
-.great-again .discussion-item-reopened .discussion-item-icon {
+.great-again .discussion-item-reopened .discussion-item-icon,
+.great-again .discussion-item-review.is-approved.is-writer .discussion-item-icon {
     background-color: #6cc644 !important;
 }
 .great-again .block-diff-added {

--- a/src/save-the-colors.css
+++ b/src/save-the-colors.css
@@ -291,6 +291,10 @@ a {
 .great-again .muted-link {
     color: #767676 !important;
 }
+/* But this overrides the hover style on the Edit/Hide/Delete dropdown menus of review comments, so we need to restore that */
+.great-again .dropdown-item:hover, .great-again .dropdown-item.zeroclipboard-is-hover {
+    color: #fff !important;
+}
 .great-again .tabnav-tab {
     color: #666;
 }


### PR DESCRIPTION
Just fixes a few colours here and there.

(I know there are always blue links creeping back in around the site. But we really need a more future-proof approach to stop them.)

I have also included a file (currently disabled) which sets all monospaced fonts on the site to use the browser's preferred monospace font face. This effectively lets the user choose which monospace font they prefer to see.

The file is not used at the moment but people can try it if they want to. If there is interest, I could turn it into a toggleable option in future.